### PR TITLE
fix the source for search domains

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -20,4 +20,3 @@ require (
 	sigs.k8s.io/cluster-api-provider-vsphere v0.7.1
 	sigs.k8s.io/controller-runtime v0.5.11
 )
-

--- a/pkg/ipam/metal3io/metal3io_ipam.go
+++ b/pkg/ipam/metal3io/metal3io_ipam.go
@@ -109,7 +109,7 @@ func (m Metal3IPAM) GetAvailableIPPool(poolMatchLabels map[string]string, cluste
 
 	//TODO: refactor searchDomains, once its added in metal3io
 	searchDomains := []string{}
-	if sdList, ok := clusterMeta.Annotations[ipam.SearchDomainsKey]; ok {
+	if sdList, ok := ipPool.Annotations[ipam.SearchDomainsKey]; ok {
 		searchDomains = strings.Split(sdList, ",")
 	}
 


### PR DESCRIPTION
What this PR does / why we need it:
This PR fixes the source of DNS search domains, to retrieve the value from IPPool annotations.

Which issue(s) this PR fixes:
Fixes #19 