### PR TITLE
Get VSphereMachine's nameservers/searchDomains from VsphereMachineTemplate, by default

### DIFF
--- a/pkg/ipam/metal3io/metal3io_ipam.go
+++ b/pkg/ipam/metal3io/metal3io_ipam.go
@@ -110,9 +110,7 @@ func (m Metal3IPAM) GetAvailableIPPool(poolMatchLabels map[string]string, cluste
 	//TODO: refactor searchDomains, once its added in metal3io
 	searchDomains := []string{}
 	if len(ipPool.Annotations[ipam.SearchDomainsKey]) > 0 {
-		if sdList, ok := ipPool.Annotations[ipam.SearchDomainsKey]; ok {
-			searchDomains = strings.Split(sdList, ",")
-		}
+		searchDomains = strings.Split(ipPool.Annotations[ipam.SearchDomainsKey], ",")
 	}
 
 	m.log.V(0).Info(fmt.Sprintf("IPPool %s is available", ipPool.Name))

--- a/pkg/ipam/metal3io/metal3io_ipam.go
+++ b/pkg/ipam/metal3io/metal3io_ipam.go
@@ -109,8 +109,10 @@ func (m Metal3IPAM) GetAvailableIPPool(poolMatchLabels map[string]string, cluste
 
 	//TODO: refactor searchDomains, once its added in metal3io
 	searchDomains := []string{}
-	if sdList, ok := ipPool.Annotations[ipam.SearchDomainsKey]; ok {
-		searchDomains = strings.Split(sdList, ",")
+	if len(ipPool.Annotations[ipam.SearchDomainsKey]) > 0 {
+		if sdList, ok := ipPool.Annotations[ipam.SearchDomainsKey]; ok {
+			searchDomains = strings.Split(sdList, ",")
+		}
 	}
 
 	m.log.V(0).Info(fmt.Sprintf("IPPool %s is available", ipPool.Name))

--- a/tests/integration/allocate_static_ip_test.go
+++ b/tests/integration/allocate_static_ip_test.go
@@ -21,12 +21,13 @@ var (
 )
 
 var _ = Describe("Static IP Allocation", func() {
-	BeforeEach(func() {})
+	BeforeEach(func() {
+		initVariables()
+	})
 	AfterEach(func() {})
 
 	Context("Reconcile vSphere resources to allocate static IP", func() {
 		It("should not error", func() {
-			initVariables()
 			createPrerequisiteResources()
 			verifyVSphereMachineStaticIPAllocation()
 			verifyNameserversAndSearchDomainsAllocation()

--- a/tests/integration/allocate_static_ip_test.go
+++ b/tests/integration/allocate_static_ip_test.go
@@ -24,11 +24,12 @@ var _ = Describe("Static IP Allocation", func() {
 	BeforeEach(func() {})
 	AfterEach(func() {})
 
-	Context("Reconcile vSphere resources", func() {
+	Context("Reconcile vSphere resources to allocate static IP", func() {
 		It("should not error", func() {
 			initVariables()
 			createPrerequisiteResources()
 			verifyVSphereMachineStaticIPAllocation()
+			verifyNameserversAndSearchDomainsAllocation()
 			verifyVSphereClusterKubeVipAllocation()
 		})
 	})

--- a/tests/integration/testenv/testdata.go
+++ b/tests/integration/testenv/testdata.go
@@ -19,6 +19,7 @@ type TestData struct {
 	KubeadmControlPlane    *v1alpha3.KubeadmControlPlane
 	Cluster                *capi.Cluster
 	Machine                *capi.Machine
+	MachineDeployment      *capi.MachineDeployment
 }
 
 func GetTestData() (*TestData, error) {
@@ -30,6 +31,7 @@ func GetTestData() (*TestData, error) {
 		KubeadmControlPlane:    &v1alpha3.KubeadmControlPlane{},
 		Cluster:                &capi.Cluster{},
 		Machine:                &capi.Machine{},
+		MachineDeployment:      &capi.MachineDeployment{},
 	}
 	all := map[string]interface{}{
 		"m3ipam_ip_pool.yaml":           td.M3IpamIPPool,
@@ -39,6 +41,7 @@ func GetTestData() (*TestData, error) {
 		"kcp.yaml":                      td.KubeadmControlPlane,
 		"capi_cluster.yaml":             td.Cluster,
 		"capi_machine.yaml":             td.Machine,
+		"capi_machinedeployment.yaml":   td.MachineDeployment,
 	}
 
 	for file, v := range all {

--- a/tests/integration/testenv/testdata/capi_machinedeployment.yaml
+++ b/tests/integration/testenv/testdata/capi_machinedeployment.yaml
@@ -1,0 +1,28 @@
+apiVersion: cluster.x-k8s.io/v1alpha3
+kind: MachineDeployment
+metadata:
+  labels:
+    cluster.x-k8s.io/cluster-name: capi-quickstart
+  name: capi-quickstart-md-0
+  namespace: default
+spec:
+  clusterName: capi-quickstart
+  replicas: 3
+  selector:
+    matchLabels: {}
+  template:
+    metadata:
+      labels:
+        cluster.x-k8s.io/cluster-name: capi-quickstart
+    spec:
+      bootstrap:
+        configRef:
+          apiVersion: bootstrap.cluster.x-k8s.io/v1alpha3
+          kind: KubeadmConfigTemplate
+          name: capi-quickstart-md-0
+      clusterName: capi-quickstart
+      infrastructureRef:
+        apiVersion: infrastructure.cluster.x-k8s.io/v1alpha3
+        kind: VSphereMachineTemplate
+        name: capi-quickstart
+      version: v1.17.3

--- a/tests/integration/testenv/testdata/m3ipam_ip_pool.yaml
+++ b/tests/integration/testenv/testdata/m3ipam_ip_pool.yaml
@@ -17,4 +17,4 @@ spec:
   prefix: 18
   gateway: 10.10.100.1
   namePrefix: capi-quickstart
-  dnsServers: [8.8.8.8]
+  dnsServers: []

--- a/tests/integration/testenv/testdata/m3ipam_ip_pool.yaml
+++ b/tests/integration/testenv/testdata/m3ipam_ip_pool.yaml
@@ -6,6 +6,8 @@ metadata:
   labels:
     cluster.x-k8s.io/ip-pool-group: dev-cluster1-masterpool-vsan-cluster
     cluster.x-k8s.io/network-name: vm-network
+  annotations:
+    cluster.x-k8s.io/dns-search-domains: ""
   uid: "UUID"
 spec:
   clusterName: capi-quickstart


### PR DESCRIPTION
What this PR does / why we need it:
This PR fixes the default source of DNS nameservers and search domains.
For a VSphereMachine, by default, the list of Nameservers and SearchDomains should be retrieved from the VSphereMachineTemplate (VSphereMachineTemplate.spec.template.spec.network[*].devices[0].searchDomains).

If an IPAM solution also provides a value for the same, that should override the default.

Which issue(s) this PR fixes:
Fixes #22  