### PR TITLE
Fetch IPPool labels from VSphereMachineTemplate, for both CP nodes and workers

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ This repository contains controllers to integrate [Kubernetes Cluster API Provid
 
 | M3IPAM version    | CAPV version     | Cluster API version |
 |-------------------|-------------------|---------------------|
-| v1alpha1 (v0.0.4) | v1alpha3 (v0.7.1) | v1alpha3 ( > v0.3.7)   |
+| v1alpha1 (v0.0.4) | v1alpha3 (v0.7.1) | v1alpha3 ( >= v0.3.7)   |
  
 ## Documentation
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ This repository contains controllers to integrate [Kubernetes Cluster API Provid
 
 | M3IPAM version    | CAPV version     | Cluster API version |
 |-------------------|-------------------|---------------------|
-| v1alpha1 (v0.0.4) | v1alpha3 (v0.7.1) | v1alpha3 (v0.3.X)   |
+| v1alpha1 (v0.0.4) | v1alpha3 (v0.7.1) | v1alpha3 ( > v0.3.7)   |
  
 ## Documentation
 

--- a/controllers/vspheremachine_controller.go
+++ b/controllers/vspheremachine_controller.go
@@ -202,13 +202,13 @@ func (r *VSphereMachineReconciler) getIPPoolMatchLabels(cli client.Client, vSphe
 	//match labels for the IPPool are retrieved from the VSphereMachineTemplate
 	vmTemplateName, ok := vSphereMachine.GetAnnotations()[capi.TemplateClonedFromNameAnnotation]
 	if !ok {
-		return nil, errors.New(fmt.Sprintf("VSphereMachine %s has no value set in the 'cloned-from-name' annotation", vSphereMachine.Name))
+		return nil, fmt.Errorf("VSphereMachine %s has no value set in the 'cloned-from-name' annotation", vSphereMachine.Name)
 	}
 
 	vsphereMachineTemplate := &infrav1.VSphereMachineTemplate{}
 	key := types.NamespacedName{Namespace: vSphereMachine.Namespace, Name: vmTemplateName}
 	if err := cli.Get(context.Background(), key, vsphereMachineTemplate); err != nil {
-		return nil, errors.New(fmt.Sprintf("failed to get VSphereMachineTemplate %s", vmTemplateName))
+		return nil, fmt.Errorf("failed to get VSphereMachineTemplate %s", vmTemplateName)
 	}
 
 	return vsphereMachineTemplate.GetLabels(), nil

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -2,7 +2,6 @@ package util
 
 import (
 	"fmt"
-	"strings"
 
 	"github.com/spectrocloud/cluster-api-provider-vsphere-static-ip/pkg/ipam"
 	corev1 "k8s.io/api/core/v1"
@@ -112,19 +111,6 @@ func GetObjRef(obj runtime.Object) corev1.ObjectReference {
 	}
 }
 
-func ConvertToLabelFormat(s string) string {
-	//lowercase, replacing '-' for space
-	return strings.ReplaceAll(strings.ToLower(s), " ", "-")
-}
-
 func GetFormattedClaimName(ownerName string, deviceCount int) string {
 	return fmt.Sprintf("%s-%d", ownerName, deviceCount)
-}
-
-func GetObjLabels(obj runtime.Object) map[string]string {
-	metaa, err := meta.Accessor(obj)
-	if err != nil {
-		return nil
-	}
-	return metaa.GetLabels()
 }

--- a/tests/integration/allocate_static_ip_func_test.go
+++ b/tests/integration/allocate_static_ip_func_test.go
@@ -331,6 +331,9 @@ func createNewVSphereMachine(name string, isMaster bool, template *infrav1.VSphe
 	if isMaster {
 		vSphereMachine.SetLabels(map[string]string{LabelControlPlane: ""})
 	}
+
+	//set 'clone-from-name' annotation, which is used to select the IPPool for the VM
+	vSphereMachine.SetAnnotations(map[string]string{capiv1alpha3.TemplateClonedFromNameAnnotation: template.Name})
 	vSphereMachine.SetOwnerReferences([]metav1.OwnerReference{
 		{
 			APIVersion: "cluster.x-k8s.io/v1alpha3",


### PR DESCRIPTION
What this PR does / why we need it:
This PR fixes the IPPool match labels issue when the IPPool label is missing in the worker VSphereMachine if its not provided in the MachineDeployment. Instead IPPool match labels are retrieved from the corresponding VSphereMachineTemplate, for both CP nodes and workers. The VSphereMachine annotation 'cluster.x-k8s.io/cloned-from-name' is used to fetch the template associated with the VSphereMachine.

Which issue(s) this PR fixes:
Fixes #24 