### PR TITLE
fix: replace ghodss/yaml with gopkg.in/yaml.v2 to address YAML DoS

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,6 @@ module github.com/spectrocloud/cluster-api-provider-vsphere-static-ip
 go 1.16
 
 require (
-	github.com/ghodss/yaml v1.0.0
 	github.com/go-logr/logr v0.4.0
 	github.com/metal3-io/ip-address-manager v0.1.1
 	github.com/metal3-io/ip-address-manager/api v0.0.0
@@ -12,6 +11,7 @@ require (
 	github.com/pkg/errors v0.9.1
 	github.com/stretchr/testify v1.7.0
 	golang.org/x/tools v0.1.9 // indirect
+	gopkg.in/yaml.v2 v2.4.0
 	k8s.io/api v0.22.2
 	k8s.io/apimachinery v0.22.2
 	k8s.io/client-go v0.22.2

--- a/go.sum
+++ b/go.sum
@@ -322,7 +322,6 @@ github.com/fvbommel/sortorder v1.0.1/go.mod h1:uk88iVf1ovNn1iLfgUVU2F9o5eO30ui72
 github.com/garyburd/redigo v0.0.0-20150301180006-535138d7bcd7/go.mod h1:NR3MbYisc3/PwhQ00EMzDiPmrwpPxAn5GI05/YaO1SY=
 github.com/getsentry/raven-go v0.2.0/go.mod h1:KungGk8q33+aIAZUIVWZDr2OfAEBsO49PX4NzFV5kcQ=
 github.com/ghodss/yaml v0.0.0-20150909031657-73d445a93680/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeMEF04=
-github.com/ghodss/yaml v1.0.0 h1:wQHKEahhL6wmXdzwWG11gIVCkOv05bNOh+Rxn0yngAk=
 github.com/ghodss/yaml v1.0.0/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeMEF04=
 github.com/globalsign/mgo v0.0.0-20180905125535-1ca0a4f7cbcb/go.mod h1:xkRDCp4j0OGD1HRkm4kmhM+pmpv3AKq5SU7GMg4oO/Q=
 github.com/globalsign/mgo v0.0.0-20181015135952-eeefdecb41b8/go.mod h1:xkRDCp4j0OGD1HRkm4kmhM+pmpv3AKq5SU7GMg4oO/Q=

--- a/tests/integration/testenv/testdata.go
+++ b/tests/integration/testenv/testdata.go
@@ -4,8 +4,8 @@ import (
 	"fmt"
 	"io/ioutil"
 
-	"github.com/ghodss/yaml"
 	ipamv1 "github.com/metal3-io/ip-address-manager/api/v1alpha1"
+	"gopkg.in/yaml.v2"
 	infrav1 "sigs.k8s.io/cluster-api-provider-vsphere/api/v1alpha4"
 	capi "sigs.k8s.io/cluster-api/api/v1alpha4"
 	"sigs.k8s.io/cluster-api/controlplane/kubeadm/api/v1alpha4"


### PR DESCRIPTION
## Summary

Replaces the unmaintained `github.com/ghodss/yaml` dependency with
`gopkg.in/yaml.v2 v2.4.0` to remediate a YAML alias-expansion
("billion laughs") denial-of-service vulnerability (CWE-776).

## Background

`ghodss/yaml` is a shim that delegates all parsing to `gopkg.in/yaml.v2`,
and pins it at the known-vulnerable `v2.2.2`. That version is missing two
security fixes:

| Fix | First in | Advisory |
|-----|----------|----------|
| Alias-expansion limit | yaml.v2 v2.2.3 | CVE-2021-4235 / GHSA-r88r-gmrh-7j83 / GO-2021-0061 |
| Flow-level / indent guards | yaml.v2 v2.2.4 | CVE-2022-3064 / GHSA-6q6q-88xp-6f2r / GO-2022-0956 |

Because the parser applies no length, depth, or alias cap, a small
(~300 byte) crafted payload can expand rapidly leading to
an OOM kill. Any code path calling `yaml.Unmarshal` on attacker-controlled
input is affected.

## Changes

- `go.mod`: drop `github.com/ghodss/yaml v1.0.0`, add `gopkg.in/yaml.v2 v2.4.0`
- `go.sum`: corresponding checksum update
- `tests/integration/testenv/testdata.go`: switch import from
  `github.com/ghodss/yaml` to `gopkg.in/yaml.v2`

`gopkg.in/yaml.v2 v2.4.0` contains both fixes and was already in the module
graph as a transitive dependency, so this removes a vulnerable direct
dependency without introducing a new one. The `Unmarshal` API is
call-compatible, so no logic changes were required.

## Testing

- `go build ./...` succeeds
- Integration test data loader compiles and links against the new import

## Risk / Compatibility

Low. The change is limited to the dependency and a single import path; the
`yaml.Unmarshal` signature and behavior used here are unchanged between the
two packages.