### PR TITLE
PCP-7232: Bump Go to 1.26.5 on master

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Build the manager binary
-FROM golang:1.16.8 as builder
+FROM golang:1.26.5 as builder
 
 WORKDIR /workspace
 # Copy the Go Modules manifests


### PR DESCRIPTION
Upgrade Dockerfile builder and go directive from 1.16 to 1.26.5.